### PR TITLE
fix broken simutils install

### DIFF
--- a/appcenter-post-clone.sh
+++ b/appcenter-post-clone.sh
@@ -3,7 +3,7 @@ mkdir simutils
 cd simutils
 curl https://raw.githubusercontent.com/wix/homebrew-brew/master/AppleSimulatorUtils-0.5.22.tar.gz -o applesimutils.tar.gz
 tar xzvf applesimutils.tar.gz
-sh buildForBrew.sh 
+sh buildForBrew.sh .
 cd ..
 export PATH=$PATH:./simutils/build/Build/Products/Release
 


### PR DESCRIPTION
there is a missing `.` in the script which leads to an error.

compare it with this one: https://github.com/Microsoft/appcenter-build-scripts-examples/blob/master/react-native/detox/appcenter-post-build.sh